### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -178,7 +178,11 @@ func (l *DiskLogger) LogRequest(method, url string, headers map[string]string) {
 	if l.config.Verbose {
 		for key, value := range headers {
 			sanitizedValue := l.SanitizeValue(key, value)
-			l.Debug("  Header: %s: %s", key, sanitizedValue)
+			if sanitizedValue != value {
+				l.Debug("  Header: %s: %s", key, sanitizedValue)
+			} else {
+				l.Debug("  Header: %s: [sanitized]", key)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ilyabrin/disk/security/code-scanning/1](https://github.com/ilyabrin/disk/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information in HTTP headers is sanitized before being logged. The `SanitizeValue` method already exists and can be leveraged for this purpose. Specifically, we need to modify the `LogRequest` method in `logger.go` to sanitize header values before passing them to the `Debug` logging call. Additionally, we should verify that all sensitive data passed to logging calls is sanitized consistently across the codebase.

**Steps to implement the fix:**
1. Update the `LogRequest` method in `logger.go` to ensure all header values are sanitized using the `SanitizeValue` method.
2. Ensure that the `Debug` logging call in `LogRequest` uses sanitized values.
3. Verify that other logging methods (e.g., `LogResponse`, `LogError`) do not log sensitive information unencrypted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
