### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -178,11 +178,7 @@ func (l *DiskLogger) LogRequest(method, url string, headers map[string]string) {
 	if l.config.Verbose {
 		for key, value := range headers {
 			sanitizedValue := l.SanitizeValue(key, value)
-			if sanitizedValue != value {
-				l.Debug("  Header: %s: %s", key, sanitizedValue)
-			} else {
-				l.Debug("  Header: %s: [sanitized]", key)
-			}
+			l.Debug("  Header: %s: %s", key, sanitizedValue)
 		}
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ilyabrin/disk/security/code-scanning/1](https://github.com/ilyabrin/disk/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information in HTTP headers is always obfuscated or omitted before being logged. Specifically, in the `LogRequest` method, we should always log the sanitized value for each header, never the original value. If a value is sanitized (i.e., replaced with asterisks or masked), we log the sanitized value; otherwise, we log the original value only if it is not sensitive. The misleading logic that logs `[sanitized]` when the value is not sanitized should be corrected. Additionally, we should review the initial request line to ensure it does not include sensitive information (though method and URL are generally safe). The changes are limited to the `LogRequest` method in `logger.go`.

**Required changes:**
- Update the header logging loop in `LogRequest` to always log the sanitized value, never the original.
- Remove the misleading `[sanitized]` log line.
- No new imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
